### PR TITLE
tweaks for testing a PR merge

### DIFF
--- a/foo.sh
+++ b/foo.sh
@@ -25,8 +25,8 @@ returnSuccessfulExitCode && echo ::set-output name=was_success::true
 FOO=abc
 BAR=xyz
 JSON_STRING=$(jq -n --arg foo "$FOO" --arg bar "$BAR" '{"FOO": [$foo], "BAR": [$bar]}')
-echo $JSON_STRING
-echo ::set-output name=matrix::$JSON_STRING
+echo "$JSON_STRING"
+echo ::set-output name=matrix::"$JSON_STRING"
 # NOTE: It's important the key's value is a list in order for GitHub Actions to
 # be able to generate a valid strategy matrix from the JSON data.
 
@@ -37,3 +37,5 @@ echo ::set-output name=custom_json::'{"BEEP": 123, "BOOP": "testing"}'
 # UPDATED syntax:
 # echo "matrix=$JSON_STRING" >> $GITHUB_OUTPUT
 # echo "custom_json='{"BEEP": 123, "BOOP": "testing"}'" >> $GITHUB_OUTPUT
+#
+# ...


### PR DESCRIPTION
Pushing a branch commit will mean `base_ref` and `head_ref` will be empty but `ref_name` will be the branch name.

But when you open a PR for that branch, the `ref_name` becomes something else entirely, while `base_ref` becomes the branch you want to merge into (e.g. `main`) while `head_ref` becomes the branch name (e.g. `integralist/TESTING`).